### PR TITLE
feat(wallet): use atomWithStorage for walletStarknetkitLatestAtom

### DIFF
--- a/state/connectedWallet.ts
+++ b/state/connectedWallet.ts
@@ -1,7 +1,7 @@
 import { ARGENT_WEBWALLET_URL, CHAIN_ID, provider } from "@/constants";
 import { atomWithStorage } from "jotai/utils";
-import type { StarknetWindowObject } from "starknetkit";
 import { connect } from "starknetkit";
+import type { StarknetWindowObject } from "starknetkit";
 
 export const walletStarknetkitLatestAtom = atomWithStorage<
 	undefined | null | StarknetWindowObject

--- a/state/connectedWallet.ts
+++ b/state/connectedWallet.ts
@@ -1,7 +1,43 @@
-import { atom } from "jotai";
-import { atomWithReset } from "jotai/utils";
-import { StarknetWindowObject } from "starknetkit";
+import { ARGENT_WEBWALLET_URL, CHAIN_ID, provider } from "@/constants";
+import { atomWithStorage } from "jotai/utils";
+import type { StarknetWindowObject } from "starknetkit";
+import { connect } from "starknetkit";
 
-export const walletStarknetkitLatestAtom = atomWithReset<
-  StarknetWindowObject | null | undefined
->(undefined);
+export const walletStarknetkitLatestAtom = atomWithStorage<
+	undefined | null | StarknetWindowObject
+>(
+	"walletStarknetkitLatest",
+	undefined,
+	{
+		getItem: async (key: string) => {
+			const value = localStorage.getItem(key);
+			const jsonWallet =
+				value && value !== "undefined" ? JSON.parse(value) : undefined;
+			if (!jsonWallet) return undefined;
+			const { wallet } = await connect({
+				provider: provider,
+				modalMode: "neverAsk",
+				webWalletUrl: ARGENT_WEBWALLET_URL,
+				argentMobileOptions: {
+					dappName: "Starknetkit example dapp",
+					url: window.location.hostname,
+					chainId: CHAIN_ID,
+					icons: [],
+				},
+			});
+			return wallet?.isConnected ? wallet : undefined;
+		},
+		setItem: async (
+			key: string,
+			value: StarknetWindowObject | null | undefined,
+		) => {
+			localStorage.setItem(key, JSON.stringify(value));
+		},
+		removeItem: async (key: string) => {
+			localStorage.removeItem(key);
+		},
+	},
+	{
+		getOnInit: true,
+	},
+);


### PR DESCRIPTION
# Pull Request

- [X] Closes #21 
- [X] Added tests (if necessary)
- [X] Run tests
- [X] Run formatting
- [X] Commented the code

## Changes description

Replace the current atomWithReset implementation with atomWithStorage; it uses local storage to save the current wallet config.

## Current output

https://github.com/user-attachments/assets/322be477-dae9-44ec-93ce-9dc9de6622ed

## Time spent breakdown

2 hours.

## Comments

Refs:
https://www.argent.xyz/blog/integrating-the-starknetkit-sdk-in-your-dapp
https://jotai.org/docs/utilities/storage
