### PR TITLE
#35 feat: add STRK price display to navbar

### DIFF
--- a/components/ui/Navbar.tsx
+++ b/components/ui/Navbar.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import ConnectWallet from "../ui/ConnectWalletButton";
+import PriceBox from "./PriceBox";  
 
 interface NavItem {
     label: string;
@@ -48,8 +49,13 @@ export const Navbar = ({
                     </div>
                 </div>
 
-                {/* Right section: Wallet Button and Mobile Menu */}
+                {/* Right section: Price Box, Wallet Button and Mobile Menu */}
                 <div className="flex items-center space-x-4">
+                    {/* Price Box */}
+                    <div className="hidden md:block">
+                        <PriceBox />
+                    </div>
+
                     {/* Wallet Button (mobile) */}
                     <div className="bottom-4 right-4 md:hidden">
                         <ConnectWallet />
@@ -87,6 +93,10 @@ export const Navbar = ({
             {isMenuOpen && (
                 <div className="md:hidden bg-white border-t border-gray-200">
                     <div className="flex flex-col space-y-2 py-3 px-4">
+                        {/* Price Box in mobile menu */}
+                        <div className="py-2">
+                            <PriceBox />
+                        </div>
                         {navItems.map((item) => (
                             <Link
                                 key={item.href}

--- a/components/ui/PriceBox.tsx
+++ b/components/ui/PriceBox.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+export default function PriceBox() {
+  const [price, setPrice] = useState(0);
+
+  useEffect(() => {
+    const fetchPrice = async () => {
+      try {
+        const response = await fetch(
+          'https://api.coingecko.com/api/v3/simple/price?ids=starknet&vs_currencies=usd'
+        );
+        const data = await response.json();
+        setPrice(data.starknet?.usd || 0);
+      } catch (error) {
+        console.error('Error fetching price:', error);
+      }
+    };
+
+    fetchPrice();
+    const interval = setInterval(fetchPrice, 60000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div className="text-sm">
+      STRK: ${price.toFixed(6)}
+    </div>
+  );
+}


### PR DESCRIPTION
# Pull Request

- [x] Closes #35

## Changes description

Added STRK price display to navbar using CoinGecko API:
- Simple price box showing current STRK/USDT price
- Auto-updates every minute
- Visible in both desktop and mobile views
- Basic error handling

## Time spent breakdown

- Research & planning: 30min
- Implementation: 1hr

## Current output

Price display is now live in the navbar, showing: "STRK: $XX.XX"

## Comments

Using CoinGecko's public API for direct price fetching.